### PR TITLE
Fix CI condition to run

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,6 +19,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_call:
 
 jobs:
   # Run our test suite on various combinations of OS & Python versions

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,7 @@ name: Publish to PyPI
 on:
   push:
     tags:
+      - '*'
 
 
 permissions:
@@ -14,6 +15,7 @@ jobs:
   # calls our general CI workflow (tests, build docs, etc.)
   tests:
     uses: ./.github/workflows/CI.yaml
+    secrets: inherit
 
   build-package:
     name: "Build & verify 🐻 Lours package"


### PR DESCRIPTION
The parsing for publish.yaml was not working, this is a fix to be able to run tests before publishing the package on Pypi