### PR TITLE
Bugfix/add requests dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Add requests dependency to the non-extra package because it is imported by
+`schema_utils_functions.py` but is only installed with the extra fiftyone #22
+
 ## [1.0.0] - 2024-09-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ print(dataset2)
 
 See some notebooks in folder `docs/notebooks`
 
-Alternatively, See <https://lours.readthedocs.io/stable/tutorials>
+Alternatively, See <https://lours.readthedocs.io/stable/tutorials.html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ pytest-regressions = "^2.5.0"
 # See https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-abi-handling
 numpy = "^1"
 scipy= ">=1, <1.14"
-
+requests= "^2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.3"


### PR DESCRIPTION
Hi!

This PR:

- Fixes add requests dependency to the non-extra package because it is imported by `schema_utils_functions.py` but is only installed with the extra fiftyone
- Fixes the tutorials url in the README