### PR TITLE
Feat/simplify split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Use networkx for chunk division for dataset splitting #71
+- Make chunk division compatible with NaN values # 71
+
 ## [1.0.1] - 2025-03-12
 
 ### Added

--- a/lours/dataset/split/disjoint_groups.py
+++ b/lours/dataset/split/disjoint_groups.py
@@ -52,11 +52,13 @@ def make_atomic_chunks(
     can make the chain :math:`(A, B) \rightarrow (A, D) \rightarrow (C, D)`, which
     means the three rows will be in the same chunk.
 
-    Note:
-        In the case the data has a ``split`` column with non NaN values, the
-        corresponding rows and the chunk they are linked to will be completely assigned
-        to that split. However, it will raise an error if a theoretically indivisible
-        chunk has rows with different split values.
+    Notes:
+        - In the case the data has a ``split`` column with non NaN values, the
+          corresponding rows and the chunk they are linked to will be completely
+          assigned to that split. However, it will be completely unassigned if a
+          theoretically indivisible chunk has rows with different split values.
+        - NaN, None or NA values are considered a unique group value, different from
+          all other values, NaN or not. This is thus equivalent to having e.g. a UUID.
 
     Args:
         data: DataFrame to be split into dissociated chunks.
@@ -71,10 +73,14 @@ def make_atomic_chunks(
             be considered unassigned.
 
     Returns:
-        1. List of DataFrames corresponding to the dissociated chunks. concatenating the
-           returned DataFrames would end up in the input DataFrame.
-        2. dictionary with already assigned atomic chunk, because the "split" value was
-           already filled in at least one of the rows
+        Tuple with 2 elements:
+
+        - List of DataFrames corresponding to the dissociated chunks.
+        - Dictionary with already assigned atomic chunk, because the "split" value was
+          already filled in at least one of the rows
+
+        concatenating the returned DataFrames in the list and the dictionary values
+        would end up in the input DataFrame.
     """
     if not groups:
         return give_already_assigned(data, split_column, split_names)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pytest-regressions = "^2.5.0"
 # See related issue on fiftyone :
 # https://github.com/voxel51/fiftyone/issues/3145
 boto3 = "1.26.83"
+networkx = "^3.4.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.3"

--- a/test_lours/test_dataset/test_split/test_disjoint_groups.py
+++ b/test_lours/test_dataset/test_split/test_disjoint_groups.py
@@ -137,3 +137,44 @@ def test_atomic_groups_nan_values():
     to_test = sorted(result_df_list, key=len)
     for df1, df2 in zip(result_df_list, to_test):
         assert_frame_equal(df1, df2)
+
+
+def test_atomic_groups_nan_values_already_assigned():
+    cols = ["a", "b", "c"]
+    test_df = pd.DataFrame(
+        [
+            [None, None, "a"],
+            [0, 1, "a"],
+            [1, 2, None],
+            [1, 3, None],
+            [2, 1, None],
+            [2, 2, None],
+            [3, 4, None],
+            [3, 5, None],
+        ],
+        columns=cols,
+    )
+    result_df_list = [
+        pd.DataFrame([[3.0, 4.0, None], [3.0, 5.0, None]], columns=cols, index=[6, 7]),
+    ]
+    result_assigned = {
+        "a": pd.DataFrame(
+            [
+                [None, None, "a"],
+                [0, 1, "a"],
+                [1, 2, "a"],
+                [1, 3, "a"],
+                [2, 1, "a"],
+                [2, 2, "a"],
+            ],
+            columns=cols,
+        )
+    }
+    to_test, assigned = disjoint_groups.make_atomic_chunks(
+        test_df, ["a", "b"], split_column="c", split_names=["a", "b"]
+    )
+    assert len(assigned) == len(result_assigned)
+    assert_frame_equal(assigned["a"], result_assigned["a"])
+    assert len(result_df_list) == len(to_test)
+    for df1, df2 in zip(result_df_list, to_test):
+        assert_frame_equal(df1, df2)

--- a/test_lours/test_dataset/test_split/test_disjoint_groups.py
+++ b/test_lours/test_dataset/test_split/test_disjoint_groups.py
@@ -4,20 +4,6 @@ from pandas.testing import assert_frame_equal
 from lours.dataset.split import disjoint_groups
 
 
-def test_cluster_set():
-    set_list = [{0, 1}, {2, 3}, {1, 2}, {4, 5}]
-    result = [{0, 1, 2}, {3}]
-    assert result == disjoint_groups.factorize_sets(set_list)
-
-    set_list = [{0, 1}, {2, 3}, {1, 2}, {4, 5}, {2, 4}]
-    result = [{0, 1, 2, 3, 4}]
-    assert result == disjoint_groups.factorize_sets(set_list)
-
-    set_list = [{0, 1, 3, 4}, {2}, {4, 5}]
-    result = [{0, 2}, {1}]
-    assert result == disjoint_groups.factorize_sets(set_list)
-
-
 def test_atomic_groups():
     cols = ["a", "b", "c"]
     test_df = pd.DataFrame(
@@ -42,6 +28,47 @@ def test_atomic_groups():
     ]
     to_test, assigned = disjoint_groups.make_atomic_chunks(test_df, ["a", "b"])
     assert not assigned
+    assert len(result_df_list) == len(to_test)
+    for df1, df2 in zip(result_df_list, to_test):
+        assert_frame_equal(df1, df2)
+
+
+def test_atomic_groups_already_assigned():
+    cols = ["a", "b", "c"]
+    test_df = pd.DataFrame(
+        [
+            [0, 0, "a"],
+            [0, 1, None],
+            [1, 2, None],
+            [1, 3, None],
+            [2, 1, None],
+            [2, 2, None],
+            [3, 4, None],
+            [3, 5, None],
+        ],
+        columns=cols,
+    )
+    result_df_list = [
+        pd.DataFrame([[3, 4, None], [3, 5, None]], columns=cols, index=[6, 7]),
+    ]
+    result_assigned = {
+        "a": pd.DataFrame(
+            [
+                [0, 0, "a"],
+                [0, 1, "a"],
+                [1, 2, "a"],
+                [1, 3, "a"],
+                [2, 1, "a"],
+                [2, 2, "a"],
+            ],
+            columns=cols,
+        )
+    }
+    to_test, assigned = disjoint_groups.make_atomic_chunks(
+        test_df, ["a", "b"], split_column="c", split_names=["a", "b"]
+    )
+    assert len(assigned) == len(result_assigned)
+    assert_frame_equal(assigned["a"], result_assigned["a"])
     assert len(result_df_list) == len(to_test)
     for df1, df2 in zip(result_df_list, to_test):
         assert_frame_equal(df1, df2)
@@ -73,5 +100,40 @@ def test_atomic_groups_three_columns():
     to_test, assigned = disjoint_groups.make_atomic_chunks(test_df, ["a", "b", "c"])
     assert not assigned
     assert len(result_df_list) == len(to_test)
+    for df1, df2 in zip(result_df_list, to_test):
+        assert_frame_equal(df1, df2)
+
+
+def test_atomic_groups_nan_values():
+    cols = ["a", "b", "c"]
+    test_df = pd.DataFrame(
+        [
+            [0, None, 6],
+            [0, 0, 7],
+            [1, 0, 6],
+            [1, 0, 7],
+            [None, 1, 8],
+            [None, None, None],
+            [3, 1, 8],
+            [3, 1, 9],
+            [None, None, None],
+        ],
+        columns=cols,
+    )
+    result_df_list = [
+        pd.DataFrame([[0, None, 6], [0, 0, 7], [1, 0, 6], [1, 0, 7]], columns=cols),
+        pd.DataFrame(
+            [[None, 1, 8], [3, 1, 8], [3, 1, 9]],
+            columns=cols,
+            index=[4, 6, 7],
+        ),
+        pd.DataFrame([[None, None, None]], columns=cols, index=[5]),
+        pd.DataFrame([[None, None, None]], columns=cols, index=[8]),
+    ]
+    to_test, assigned = disjoint_groups.make_atomic_chunks(test_df, ["a", "b", "c"])
+    assert not assigned
+    assert len(result_df_list) == len(to_test)
+    result_df_list = sorted(result_df_list, key=len)
+    to_test = sorted(result_df_list, key=len)
     for df1, df2 in zip(result_df_list, to_test):
         assert_frame_equal(df1, df2)


### PR DESCRIPTION
# Pull Request

## Describe your changes

- Improve splitting mechanism by simplifying chunk division. We now use networkx capabilities, making it much simpler.
- Add the possibility to have NaN values in the keep separate groups, which means that we don't really care for this row, so it's equivalent to a unique identifier, like a UUID for example.

## Issue number if applicable

## Checklist before requesting a review

Github actions will check that these tasks were performed but it will reduce friction if you deal with them beforhand

- [x] If code is added, the new lines are covered by tests (Checked by [Codecov](https://app.codecov.io/gh/XXII-AI/Lours))
- [x] Type hints are consistent (Checked by [pyright](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L95) Job)
- [x] Code style follows black conventions (Checked by [pre-commit](https://results.pre-commit.ci/repo/github/816858832))
- [x] If documentation is added, it does not raise a warning in sphinx (checked by [sphinx-build](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L65))
- [x] CHANGELOG has been updated if applicable
