### PR TITLE
Improve splitting mechanism when some values are already assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Fix a bug in splitting were already assigned split values were discarded #74
+
+### Added
+
+- Add taking into account already assigned values when doing simple split #74
+
 ## [1.1.0] - 2025-03-13
 
 ### Changed
 
 - Use networkx for chunk division for dataset splitting #71
-- Make chunk division compatible with NaN values # 71
+- Make chunk division compatible with NaN values #71
 
 ## [1.0.1] - 2025-03-12
 

--- a/lours/dataset/dataset.py
+++ b/lours/dataset/dataset.py
@@ -22,7 +22,7 @@ from ..utils.column_booleanizer import booleanize, debooleanize, get_bool_column
 from ..utils.grouper import get_group_names, group_list, groups_to_list
 from ..utils.label_map_merger import IncompatibleLabelMapsError
 from ..utils.parquet_saver import dict_to_parquet
-from .split.dataset_splitter import split_dataframe
+from .split.dataset_splitter import simple_split_dataframe, split_dataframe
 
 if TYPE_CHECKING:
     import fiftyone as fo
@@ -4369,30 +4369,17 @@ class Dataset:
             valid    0.275
             Name: count, dtype: float64
         """
-        if len(split_names) <= 1:
-            raise ValueError(
-                f"Must provide at least 2 split names. Got {split_names} of size"
-                f" {len(split_names)} instead."
-            )
-        if len(target_split_shares) != len(split_names):
-            raise ValueError(
-                "Size mismatch between 'split_names' and 'split_shares'"
-                f" ({len(split_names)} vs {len(target_split_shares)})"
-            )
-        if sum(target_split_shares) != 1:
-            raise ValueError(
-                "Split share values must addup to 1. Got"
-                f" {sum(target_split_shares)} instead"
-            )
-        gen = np.random.default_rng(input_seed)
-        split = gen.choice(
-            list(split_names), size=len(self), p=list(target_split_shares)
+        splitted_images = simple_split_dataframe(
+            self.images,
+            input_seed=input_seed,
+            split_names=split_names,
+            target_split_shares=target_split_shares,
+            inplace=inplace,
         )
         if inplace:
-            self.images["split"] = split
             return self
         else:
-            return self.from_template(images=self.images.assign(split=split))
+            return self.from_template(images=splitted_images)
 
     def split(
         self,
@@ -4531,7 +4518,7 @@ class Dataset:
             1 chunks to distribute across 2 splits
             Splitting images ...
             Separating input data into atomic chunks
-            10 chunks to distribute across 2 splits
+            9 chunks to distribute across 2 splits
             >>> splitted
             Dataset object containing 200 images and 2 objects
             Name :
@@ -4547,8 +4534,8 @@ class Dataset:
             3      840     384        like/safe.bmp   .bmp  train  anything   likely
             4      953     668      suffer/set.jpeg  .jpeg  train  training   attack
             ..     ...     ...                  ...    ...    ...       ...      ...
-            195    122     437    state/almost.tiff  .tiff  valid  anything     star
-            196    752     300     weight/tend.jpeg  .jpeg  train     could     rest
+            195    122     437    state/almost.tiff  .tiff  train  anything     star
+            196    752     300     weight/tend.jpeg  .jpeg  valid     could     rest
             197    554     228  remember/summer.png   .png  train  anything   system
             198    688     605       yet/though.png   .png  train      note   number
             199    243     227   describe/road.tiff  .tiff  train       end   number
@@ -4565,66 +4552,51 @@ class Dataset:
             {14: 'listen', 15: 'marriage', 22: 'reach'}
             >>> splitted.images.groupby("split")["separate"].value_counts()
             split  separate
-            train  likely      27
+            train  star        27
+                   likely      27
                    number      27
                    attack      22
-                   rest        20
                    entire      17
                    enough      16
                    system      15
-                   often       11
-                   star         0
-                   law          0
-            valid  star        27
-                   law         18
-                   entire       0
-                   attack       0
                    rest         0
+                   law          0
+                   often        0
+            valid  rest        20
+                   law         18
+                   often       11
+                   entire       0
+                   star         0
+                   attack       0
                    likely       0
                    system       0
-                   often        0
                    enough       0
                    number       0
             Name: count, dtype: int64
             >>> splitted.images.groupby("split")["balanced"].value_counts()
             split  balanced
             train  could       21
-                   coach       21
-                   send        19
-                   firm        18
-                   end         17
+                   coach       20
+                   end         20
+                   firm        17
+                   send        16
                    anything    14
-                   training    14
-                   region      11
+                   training    13
                    lead        10
                    note        10
+                   region      10
             valid  could        8
-                   end          7
+                   send         8
                    note         6
+                   firm         5
                    anything     5
-                   send         5
-                   firm         4
-                   training     3
-                   region       3
+                   training     4
+                   region       4
+                   end          4
+                   coach        3
                    lead         2
-                   coach        2
             Name: count, dtype: int64
         """
-        if len(split_names) <= 1:
-            raise ValueError(
-                f"Must provide at least 2 split names. Got {split_names} of size"
-                f" {len(split_names)} instead."
-            )
-        if len(target_split_shares) != len(split_names):
-            raise ValueError(
-                "Size mismatch between 'split_names' and 'split_shares'"
-                f" ({len(split_names)} vs {len(target_split_shares)})"
-            )
-        if sum(target_split_shares) != 1:
-            raise ValueError(
-                "Split share values must addup to 1. Got"
-                f" {sum(target_split_shares)} instead"
-            )
         if (
             (not keep_separate_groups)
             or keep_separate_groups == "image_id"

--- a/lours/dataset/dataset.py
+++ b/lours/dataset/dataset.py
@@ -4611,9 +4611,7 @@ class Dataset:
         keep_separate_groups = groups_to_list(keep_separate_groups)
         keep_balanced_groups = groups_to_list(keep_balanced_groups)
 
-        if keep_balanced_groups_weights is None:
-            keep_balanced_groups_weights = [1] * len(keep_balanced_groups)
-        else:
+        if keep_balanced_groups_weights is not None:
             keep_balanced_groups_weights = [*keep_balanced_groups_weights]
 
         keep_balanced_group_names = get_group_names(keep_balanced_groups)
@@ -4626,9 +4624,13 @@ class Dataset:
         keep_balanced_image_groups = [
             keep_balanced_groups[i] for i in keep_balanced_image_groups_indices
         ]
-        keep_balanced_image_groups_weights = [
-            keep_balanced_groups_weights[i] for i in keep_balanced_image_groups_indices
-        ]
+        if keep_balanced_groups_weights is not None:
+            keep_balanced_image_groups_weights = [
+                keep_balanced_groups_weights[i]
+                for i in keep_balanced_image_groups_indices
+            ]
+        else:
+            keep_balanced_image_groups_weights = None
 
         keep_separate_group_names = get_group_names(keep_separate_groups)
         keep_separate_image_groups = [
@@ -4672,8 +4674,6 @@ class Dataset:
         )
 
         if inplace:
-            self.images = splitted_images
-            self.annotations = splitted_annotations
             return self
 
         return self.from_template(

--- a/lours/dataset/split/dataset_splitter.py
+++ b/lours/dataset/split/dataset_splitter.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Sequence
 from random import seed, shuffle
 from typing import overload
 from warnings import warn
@@ -129,18 +129,122 @@ def get_winner(
     return winner, split_hists, split_hists_distances, split_sizes
 
 
+def check_split_target(
+    split_names: Sequence[str], target_split_shares: Sequence[float]
+) -> pd.Series:
+    if len(split_names) <= 1:
+        raise ValueError(
+            f"Must provide at least 2 split names. Got {split_names} of size"
+            f" {len(split_names)} instead."
+        )
+    if len(target_split_shares) != len(split_names):
+        raise ValueError(
+            "Size mismatch between 'split_names' and 'split_shares'"
+            f" ({len(split_names)} vs {len(target_split_shares)})"
+        )
+    if sum(target_split_shares) != 1:
+        raise ValueError(
+            "Split share values must addup to 1. Got"
+            f" {sum(target_split_shares)} instead"
+        )
+
+    return pd.Series(list(target_split_shares), index=list(split_names))
+
+
+def simple_split_dataframe(
+    input_data: pd.DataFrame,
+    input_seed: int = 0,
+    split_names: Sequence[str] = ("train", "valid"),
+    target_split_shares: Sequence[float] = (0.8, 0.2),
+    inplace: bool = False,
+) -> pd.DataFrame:
+    """Simple version of splitting method, splitting unassigned rows randomly.
+
+    Note:
+        If target split shares and already assigned rows are incompatible, a warning
+        will be issued, and the splitting process will continueusing relative target
+        shares for remaining splits instead.
+
+    Args:
+        input_data: DataFrame to assign split values.
+        input_seed: Random seed for splitting images. Defaults to 0.
+        split_names: Names of splits. Must be more than 1 element long and the same
+            size as ``target_split_shares``. Defaults to ``("train", "valid")``.
+        target_split_shares: Share values of each split. Must be the same size as
+            ``split_names``. Must add up to 1. Defaults to ``(0.8, 0.2)``.
+        inplace: If set to True, will perform the splitting inplace without creating
+            a new dataset. Defaults to False.
+
+    Returns:
+        DataFrame with new splits applied to its ``split`` column.
+    """
+    target_split_shares_series = check_split_target(
+        split_names=split_names, target_split_shares=target_split_shares
+    )
+    split_sizes = pd.Series(0, index=list(split_names))
+    gen = np.random.default_rng(input_seed)
+    if "split" in input_data.columns:
+        already_assigned = input_data["split"].value_counts()
+        split = input_data["split"] if inplace else input_data["split"].copy()
+        for split_name, value in already_assigned.items():
+            try:
+                split_sizes[split_name] = value
+            except KeyError:
+                # Split name not wanted, we reset it
+                split.loc[split == split_name] = None
+
+    else:
+        split = pd.Series(None, index=input_data.index, dtype=object)
+
+    target_split_sizes_series = target_split_shares_series * len(input_data)
+    residual_target_split_sizes = target_split_sizes_series - split_sizes
+    if residual_target_split_sizes.min() < 0:
+        too_big_splits = residual_target_split_sizes[
+            residual_target_split_sizes < 0
+        ].index
+        split_shares = split_sizes / len(input_data)
+        too_big_str = [
+            f"{name}: {target_split_shares_series[name]} (target) vs "
+            f"{split_shares[name]} (already assigned)"
+            for name in too_big_splits
+        ]
+        warn(
+            "The following split already have too much samples assigned regarding "
+            f"target shares : {', '.join(too_big_str)}. The process will assign "
+            "remaining split values in order to respect their relative share, but "
+            "the target share will not be met. You might want to reset your "
+            "already assigned split values or use less restrictive split target "
+            "shares.",
+            RuntimeWarning,
+        )
+
+    # Compute residual target shares, and apply this splitting to the not assigned rows.
+    residual_target_split_sizes = residual_target_split_sizes.clip(0)
+    residual_target_split_shares = (
+        residual_target_split_sizes / residual_target_split_sizes.sum()
+    )
+    split.loc[split.isna()] = gen.choice(
+        list(split_names), size=split.isna().sum(), p=list(residual_target_split_shares)
+    )
+    if inplace:
+        input_data["split"] = split
+    else:
+        input_data = input_data.assign(split=split)
+    return input_data
+
+
 @overload
 def split_dataframe(
     input_data: pd.DataFrame,
     root_data: pd.DataFrame,
     key_to_root: str = "image_id",
     input_seed: int = 0,
-    split_names: Iterable[str] = ("train", "valid"),
-    target_split_shares: Iterable[float] = (0.8, 0.2),
+    split_names: Sequence[str] = ("train", "valid"),
+    target_split_shares: Sequence[float] = (0.8, 0.2),
     split_column_name: str = "split",
     keep_separate_groups: group_list = ("image_id",),
     keep_balanced_groups: group_list = ("category_id",),
-    keep_balanced_groups_weights: Iterable[float] | None = None,
+    keep_balanced_groups_weights: Sequence[float] | None = None,
     inplace: bool = False,
     split_at_root_level: bool = False,
     hist_cost_weight: float = 1,
@@ -156,12 +260,12 @@ def split_dataframe(
     root_data: None = None,
     key_to_root: str = "image_id",
     input_seed: int = 0,
-    split_names: Iterable[str] = ("train", "valid"),
-    target_split_shares: Iterable[float] = (0.8, 0.2),
+    split_names: Sequence[str] = ("train", "valid"),
+    target_split_shares: Sequence[float] = (0.8, 0.2),
     split_column_name: str = "split",
     keep_separate_groups: group_list = ("image_id",),
     keep_balanced_groups: group_list = ("category_id",),
-    keep_balanced_groups_weights: Iterable[float] | None = None,
+    keep_balanced_groups_weights: Sequence[float] | None = None,
     inplace: bool = False,
     split_at_root_level: bool = False,
     hist_cost_weight: float = 1,
@@ -177,12 +281,12 @@ def split_dataframe(
     root_data: pd.DataFrame | None = None,
     key_to_root: str = "image_id",
     input_seed: int = 0,
-    split_names: Iterable[str] = ("train", "valid"),
-    target_split_shares: Iterable[float] = (0.8, 0.2),
+    split_names: Sequence[str] = ("train", "valid"),
+    target_split_shares: Sequence[float] = (0.8, 0.2),
     split_column_name: str = "split",
     keep_separate_groups: group_list = ("image_id",),
     keep_balanced_groups: group_list = ("category_id",),
-    keep_balanced_groups_weights: Iterable[float] | None = None,
+    keep_balanced_groups_weights: Sequence[float] | None = None,
     inplace: bool = False,
     split_at_root_level: bool = False,
     hist_cost_weight: float = 1,
@@ -197,12 +301,12 @@ def split_dataframe(
     root_data: pd.DataFrame | None = None,
     key_to_root: str = "image_id",
     input_seed: int = 0,
-    split_names: Iterable[str] = ("train", "valid"),
-    target_split_shares: Iterable[float] = (0.8, 0.2),
+    split_names: Sequence[str] = ("train", "valid"),
+    target_split_shares: Sequence[float] = (0.8, 0.2),
     split_column_name: str = "split",
     keep_separate_groups: group_list = ("image_id",),
     keep_balanced_groups: group_list = ("category_id",),
-    keep_balanced_groups_weights: Iterable[float] | None = None,
+    keep_balanced_groups_weights: Sequence[float] | None = None,
     inplace: bool = False,
     split_at_root_level: bool = False,
     hist_cost_weight: float = 1,
@@ -270,8 +374,9 @@ def split_dataframe(
         new annotation and root_data with the split column populated with the
         corresponding split name.
     """
-    target_split_shares = pd.Series(list(target_split_shares), index=[*split_names])
-    target_split_shares /= target_split_shares.sum()
+    target_split_shares_series = check_split_target(
+        split_names=split_names, target_split_shares=target_split_shares
+    )
 
     keep_balanced_groups = groups_to_list(keep_balanced_groups)
     for g in keep_balanced_groups:
@@ -281,11 +386,11 @@ def split_dataframe(
     keep_separate_groups = groups_to_list(keep_separate_groups)
 
     if keep_balanced_groups_weights is None:
-        keep_balanced_groups_weights = pd.Series(
+        keep_balanced_groups_weights_series = pd.Series(
             1, index=keep_balanced_group_names, dtype=float
         )
     else:
-        keep_balanced_groups_weights = pd.Series(
+        keep_balanced_groups_weights_series = pd.Series(
             list(keep_balanced_groups_weights),
             index=keep_balanced_group_names,
             dtype=float,
@@ -330,23 +435,25 @@ def split_dataframe(
         data=input_data,
         groups=keep_separate_input_pandas_groups,
         split_column=split_column_name,
-        split_names=target_split_shares.index,  # pyright: ignore
+        split_names=target_split_shares_series.index,  # pyright: ignore
     )
     if not atomic_chunks:
         print("No chunk to distribute")
     else:
         print(
             f"{len(atomic_chunks)} chunks to distribute"
-            f" across {len(target_split_shares)} splits"
+            f" across {len(target_split_shares_series)} splits"
         )
 
     # Construct a split dictionary, containing the indexes of input_data, belonging
     # to each split
-    splits: dict[str, list] = {str(name): [] for name in target_split_shares.index}
-    split_sizes = pd.Series(0, index=target_split_shares.index)
+    splits: dict[str, list] = {
+        str(name): [] for name in target_split_shares_series.index
+    }
+    split_sizes = pd.Series(0, index=target_split_shares_series.index)
 
     def share_cost_function(candidate_shares: pd.Series) -> float:
-        return dataset_share_distance(target_split_shares, candidate_shares)
+        return dataset_share_distance(target_split_shares_series, candidate_shares)
 
     (
         keep_balanced_groups_dict,
@@ -359,11 +466,11 @@ def split_dataframe(
         key_to_root=key_to_root,
     )
 
-    category_weights = keep_balanced_groups_weights[
-        keep_balanced_groups_weights.index.isin(category_groups)
+    category_weights = keep_balanced_groups_weights_series[
+        keep_balanced_groups_weights_series.index.isin(category_groups)
     ]
-    continuous_weights = keep_balanced_groups_weights[
-        keep_balanced_groups_weights.index.isin(continuous_groups)
+    continuous_weights = keep_balanced_groups_weights_series[
+        keep_balanced_groups_weights_series.index.isin(continuous_groups)
     ]
 
     keep_balanced_pandas_groups = list(keep_balanced_groups_dict.values())
@@ -373,7 +480,7 @@ def split_dataframe(
         # their construction. split_hists is a dataframe of histograms.
         # Each column is a split
         split_hists = pd.DataFrame(
-            0, index=target_hist.index, columns=target_split_shares.index
+            0, index=target_hist.index, columns=target_split_shares_series.index
         )
 
         # Function that we will apply to the split histogram dataframe

--- a/lours/dataset/split/dataset_splitter.py
+++ b/lours/dataset/split/dataset_splitter.py
@@ -187,9 +187,9 @@ def simple_split_dataframe(
         already_assigned = input_data["split"].value_counts()
         split = input_data["split"] if inplace else input_data["split"].copy()
         for split_name, value in already_assigned.items():
-            try:
+            if split_name in split_sizes.index:
                 split_sizes[split_name] = value
-            except KeyError:
+            else:
                 # Split name not wanted, we reset it
                 split.loc[split == split_name] = None
 

--- a/lours/dataset/split/disjoint_groups.py
+++ b/lours/dataset/split/disjoint_groups.py
@@ -105,21 +105,21 @@ def make_atomic_chunks(
         already_assigned_chunks[name].append(split)
     if split_column in data.columns:
         for df in df_list:
-            split_names = [
+            chunk_split_names = [
                 name
                 for name in df[split_column].dropna().unique()
                 if name in split_names
             ]
-            if len(split_names) > 1:
-                split_names_str = ", ".join(map(str, split_names))
+            if len(chunk_split_names) > 1:
+                split_names_str = ", ".join(map(str, chunk_split_names))
                 warnings.warn(
                     "One chunk has multiple split assignments"
                     f" ({split_names_str}) and will be treated as unassigned",
                     RuntimeWarning,
                 )
                 unassigned.append(df)
-            elif len(split_names) == 1:
-                split_name = split_names[0]
+            elif len(chunk_split_names) == 1:
+                split_name = chunk_split_names[0]
                 df[split_column] = split_name
                 already_assigned_chunks[split_name].append(df)
             else:

--- a/lours/evaluation/detection/detection_evaluator.py
+++ b/lours/evaluation/detection/detection_evaluator.py
@@ -635,7 +635,7 @@ class DetectionEvaluator(DetectionEvaluatorBase):
                 print(f"Processing PR curve for model={p_name} and IOU={iou}")
                 if pandas_groups:
                     precision_recall_curve = results.groupby(
-                        pandas_groups, sort=False
+                        pandas_groups, sort=False, observed=True
                     ).progress_apply(  # pyright: ignore
                         partial(
                             pr_curve,
@@ -668,7 +668,7 @@ class DetectionEvaluator(DetectionEvaluatorBase):
 
         precision_recall_curves = pd.concat(precision_recall_curves, ignore_index=True)
         average_precisions = precision_recall_curves.groupby(
-            group_names + ["iou_threshold", "model"], sort=False
+            group_names + ["iou_threshold", "model"], sort=False, observed=True
         ).apply(compute_average_precision, include_groups=False)
         average_precisions = average_precisions.rename("AP").reset_index()
         if "category_id" in group_names:

--- a/test_lours/test_dataset/test_split/test_split.py
+++ b/test_lours/test_dataset/test_split/test_split.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
+import pytest
 from numpy.testing import assert_almost_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
 
@@ -53,6 +55,51 @@ def test_coco_already_assigned_split():
     )
 
     assert_series_equal(former_split, splitted_coco.images["split"])
+
+
+def test_coco_already_assigned_split2():
+    coco = from_coco(
+        coco_json=DATA / "coco_eval/instances_val2017.json",
+        images_root=Path("."),
+        split="valid",
+    )
+    coco = coco[::100]
+    coco.images["fake_category"] = np.random.choice([0, 1], len(coco), p=[0.2, 0.8])
+    coco.images["split"] = None
+    coco.images.loc[coco.images["fake_category"] == 0, "split"] = "train"
+
+    splitted_coco = coco.split(
+        input_seed=1,
+        split_names=["train", "valid"],
+        target_split_shares=[0.9, 0.1],
+        keep_separate_groups=["image_id"],
+        keep_balanced_groups=["category_id"],
+    )
+
+    assert 0 not in splitted_coco.get_split("valid").images["fake_category"].to_numpy()
+    assert 0 in splitted_coco.get_split("train").images["fake_category"].to_numpy()
+
+
+def test_coco_already_assigned_split_warning():
+    coco = from_coco(
+        coco_json=DATA / "coco_eval/instances_val2017.json",
+        images_root=Path("."),
+        split="valid",
+    )
+    coco = coco[::100]
+    coco.annotations["split"] = np.random.choice(
+        ["train", "valid"], coco.len_annot(), p=[0.5, 0.5]
+    )
+    assert coco.annotations.groupby("image_id")["split"].unique().apply(len).max() == 2
+
+    with pytest.warns(RuntimeWarning):
+        coco.split(
+            input_seed=1,
+            split_names=["train", "valid"],
+            target_split_shares=[0.9, 0.1],
+            keep_separate_groups=["image_id"],
+            keep_balanced_groups=["category_id"],
+        )
 
 
 def test_coco_balanced_category_split():
@@ -144,3 +191,96 @@ def test_balanced_two_continuous_split():
         splitted_coco
     )
     assert_almost_equal([0.9, 0.1], result_shares_images[["train", "valid"]])
+
+
+def test_simple_split():
+    coco = from_coco(
+        coco_json=DATA / "coco_eval/instances_val2017.json", images_root=Path(".")
+    )
+    coco.images.split = None
+
+    splitted_coco = coco.split(
+        input_seed=1,
+        split_names=["train", "valid"],
+        target_split_shares=[0.9, 0.1],
+        keep_separate_groups=["image_id"],
+        keep_balanced_groups=[],
+    )
+
+    split_share_target = pd.Series([0.9, 0.1], index=["train", "valid"])
+    result_share = splitted_coco.images["split"].value_counts() / len(coco)
+
+    assert_series_equal(
+        split_share_target,
+        result_share,
+        check_exact=False,
+        check_like=True,
+        check_names=False,
+        atol=1e-2,
+    )
+
+
+def test_simple_split_already_assigned():
+    coco = from_coco(
+        coco_json=DATA / "coco_eval/instances_val2017.json", images_root=Path(".")
+    )
+    coco.images.split = None
+    gen = np.random.default_rng(1)
+    to_assign = gen.choice([True, False], size=len(coco), p=[0.2, 0.8])
+    coco.images.loc[to_assign, "split"] = "train"
+    splitted_coco = coco.split(
+        input_seed=1,
+        split_names=["train", "valid"],
+        target_split_shares=[0.9, 0.1],
+        keep_separate_groups=["image_id"],
+        keep_balanced_groups=[],
+    )
+
+    split_share_target = pd.Series([0.9, 0.1], index=["train", "valid"])
+    result_share = splitted_coco.images["split"].value_counts() / len(coco)
+
+    assert_series_equal(
+        split_share_target,
+        result_share,
+        check_exact=False,
+        check_like=True,
+        check_names=False,
+        atol=1e-2,
+    )
+
+    assert list(coco.images.loc[to_assign, "split"].unique()) == ["train"]
+
+
+def test_simple_split_too_many_already_assigned():
+    coco = from_coco(
+        coco_json=DATA / "coco_eval/instances_val2017.json", images_root=Path(".")
+    )
+    coco.images.split = None
+    gen = np.random.default_rng(1)
+    to_assign = gen.choice([True, False], size=len(coco), p=[0.2, 0.8])
+    coco.images.loc[to_assign, "split"] = "valid"
+    with pytest.warns(RuntimeWarning):
+        splitted_coco = coco.split(
+            input_seed=0,
+            split_names=["train", "valid", "test"],
+            target_split_shares=[0.8, 0.1, 0.1],
+            keep_separate_groups=["image_id"],
+            keep_balanced_groups=[],
+        )
+
+    split_share_target = pd.Series(
+        [0.8 * 0.8 / 0.9, 0.2, 0.1 * 0.8 / 0.9], index=["train", "valid", "test"]
+    )
+    result_share = splitted_coco.images["split"].value_counts() / len(coco)
+
+    assert_series_equal(
+        split_share_target,
+        result_share,
+        check_exact=False,
+        check_like=True,
+        check_names=False,
+        atol=1e-2,
+    )
+
+    assert list(coco.images.loc[to_assign, "split"].unique()) == ["valid"]
+    assert "valid" not in coco.images.loc[~to_assign, "split"].values


### PR DESCRIPTION
# Pull Request

## Describe your changes

* Fix a bug in disjoint_groups where already assigned values were discarded and thus reset
* Add tests that failed before and that now regarding this feature
* Take already assigned split into account when doing simple split
* Move simple split to dataset_splitter module
* Remove some warnings


## Issue number if applicable

## Checklist before requesting a review

Github actions will check that these tasks were performed but it will reduce friction if you deal with them beforhand

- [x] If code is added, the new lines are covered by tests (Checked by [Codecov](https://app.codecov.io/gh/XXII-AI/Lours))
- [x] Type hints are consistent (Checked by [pyright](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L95) Job)
- [x] Code style follows black conventions (Checked by [pre-commit](https://results.pre-commit.ci/repo/github/816858832))
- [x] If documentation is added, it does not raise a warning in sphinx (checked by [sphinx-build](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L65))
- [x] CHANGELOG has been updated if applicable
