### PR TITLE
Do not import pytest regression if regression extra is not installed

### DIFF
--- a/lours/utils/regression_testing.py
+++ b/lours/utils/regression_testing.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 from imageio import imread
-from pytest_regressions.common import perform_regression_check
 
 from lours.dataset import Dataset, from_parquet
 
@@ -124,6 +123,14 @@ class DataSetRegressionFixture:
         dump_fn = functools.partial(
             self.dump_fn, dataset, with_image_checksum=check_images
         )
+
+        try:
+            from pytest_regressions.common import perform_regression_check
+        except ImportError as e:
+            raise ImportError(
+                "Pytest regression is not installed, reinstall Lours with "
+                "'regression' extra dependency"
+            ) from e
 
         perform_regression_check(
             datadir=self.datadir,


### PR DESCRIPTION
# Pull Request

## Describe your changes

There was a problem when installing lours package without the regression extras and running pytest.

Pytest discovers all pytest11 plugins and thus imports necessary files.
With this PR, the pytest_regression optinal package is only import when the fixture is called which makes a reasonable error.

## Issue number if applicable

## Checklist before requesting a review

Github actions will check that these tasks were performed but it will reduce friction if you deal with them beforhand

- [ ] If code is added, the new lines are covered by tests (Checked by [Codecov](https://app.codecov.io/gh/XXII-AI/Lours))
- [x] Type hints are consistent (Checked by [pyright](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L95) Job)
- [x] Code style follows black conventions (Checked by [pre-commit](https://results.pre-commit.ci/repo/github/816858832))
- [x] If documentation is added, it does not raise a warning in sphinx (checked by [sphinx-build](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L65))
- [x] CHANGELOG has been updated if applicable
