### PR TITLE
Fix regression testing that does not allow category anymore

### DIFF
--- a/docs/notebooks/3_demo_evaluation_detection.ipynb
+++ b/docs/notebooks/3_demo_evaluation_detection.ipynb
@@ -3294,8 +3294,7 @@
    "outputs": [],
    "source": [
     "recall_at_precision_persons = persons.groupby(\"box_height\").apply(\n",
-    "    partial(interpolate_precision, value=np.linspace(0.1, 0.9, 5).round(3)),\n",
-    "    include_groups=False,\n",
+    "    partial(interpolate_precision, value=np.linspace(0.1, 0.9, 5).round(3))\n",
     ")\n",
     "recall_at_precision_persons = recall_at_precision_persons.reset_index()\n",
     "recall_at_precision_persons[\"box_mean_height\"] = recall_at_precision_persons[\n",
@@ -3393,8 +3392,7 @@
    "source": [
     "all_classes_iou_05 = pr[pr[\"iou_threshold\"] == 0.5]\n",
     "recall_at_precision = all_classes_iou_05.groupby([\"box_height\", \"category_id\"]).apply(\n",
-    "    partial(interpolate_precision, value=np.linspace(0.1, 0.9, 5).round(2)),\n",
-    "    include_groups=False,\n",
+    "    partial(interpolate_precision, value=np.linspace(0.1, 0.9, 5).round(2))\n",
     ")\n",
     "recall_at_precision = recall_at_precision.reset_index()\n",
     "recall_at_precision[\"box_mean_height\"] = recall_at_precision[\"box_height\"].apply(\n",

--- a/lours/evaluation/detection/detection_evaluator.py
+++ b/lours/evaluation/detection/detection_evaluator.py
@@ -174,7 +174,7 @@ class DetectionEvaluator(DetectionEvaluatorBase):
                 groups.append("category_id")
             grouped = groundtruth_prediction.groupby(groups, group_keys=False)
             matches[prediction_name] = grouped.progress_apply(  # pyright: ignore
-                partial(construct_matches_df, min_iou=min_iou), include_groups=False
+                partial(construct_matches_df, min_iou=min_iou)
             )
         return matches
 
@@ -644,8 +644,7 @@ class DetectionEvaluator(DetectionEvaluatorBase):
                             min_iou=iou,
                             reindex_series=reindex_series,
                             betas=f_scores_betas,
-                        ),
-                        include_groups=False,
+                        )
                     )
                     # Groups are currently in the multiIndex. Reset it to make the
                     # dataframe easier to use: rename the index with the group names and
@@ -671,7 +670,7 @@ class DetectionEvaluator(DetectionEvaluatorBase):
         precision_recall_curves = pd.concat(precision_recall_curves, ignore_index=True)
         average_precisions = precision_recall_curves.groupby(
             group_names + ["iou_threshold", "model"], sort=False, observed=True
-        ).apply(compute_average_precision, include_groups=False)
+        ).apply(compute_average_precision)
         average_precisions = average_precisions.rename("AP").reset_index()
         if "category_id" in group_names:
             precision_recall_curves["category_str"] = precision_recall_curves[

--- a/test_lours/test_utils/test_doc_utils.py
+++ b/test_lours/test_utils/test_doc_utils.py
@@ -111,7 +111,10 @@ def test_column_specs(dataframe_regression):
         numpy_generator=gen,
     )
 
-    dataframe_regression.check(dataframe_to_test)
+    # categorical data is not accepted anymore for regression testing
+    # so we convert to string.
+    # See https://github.com/ESSS/pytest-regressions/issues/197
+    dataframe_regression.check(dataframe_to_test.astype(str))
 
     np.testing.assert_allclose(
         dataframe_to_test["col5"].value_counts().to_numpy() / length,


### PR DESCRIPTION
# Pull Request

## Describe your changes

Convert dataframe to string before checking regression.
See https://github.com/ESSS/pytest-regressions/issues/197

## Issue number if applicable

## Checklist before requesting a review

Github actions will check that these tasks were performed but it will reduce friction if you deal with them beforhand

- [X] If code is added, the new lines are covered by tests (Checked by [Codecov](https://app.codecov.io/gh/XXII-AI/Lours))
- [X] Type hints are consistent (Checked by [pyright](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L95) Job)
- [X] Code style follows black conventions (Checked by [pre-commit](https://results.pre-commit.ci/repo/github/816858832))
- [x] If documentation is added, it does not raise a warning in sphinx (checked by [sphinx-build](https://github.com/XXII-AI/Lours/blob/main/.github/workflows/CI.yaml#L65))
- [ ] CHANGELOG has been updated if applicable
